### PR TITLE
Inchworm order of operation (#21) removed duplicate funcs

### DIFF
--- a/inchworm_control/block_simulation/inchworm_data.py
+++ b/inchworm_control/block_simulation/inchworm_data.py
@@ -121,11 +121,12 @@ class Inchworm:
     
     def plan_path(self, next_goal: tuple[int, int, int] = None): 
         """ Plan path from current location to specified goal. """
+        print(Fore.MAGENTA +"lagging foot loc: ", self.lagging_foot_loc)
         is_traveling = False # assumes that if not specified, objective is to travel, not place
         if next_goal == None:
             print(Fore.MAGENTA + "goal not given... finding goal now")
-            print(Fore.MAGENTA + "(PP) current_map: ", self.current_map)
-            print(Fore.MAGENTA + "(PP) final_map: ", self.final_structure)
+            # print(Fore.MAGENTA + "(PP) current_map: ", self.current_map)
+            # print(Fore.MAGENTA + "(PP) final_map: ", self.final_structure)
             self.goal = blueprint(self.current_map, self.final_structure) # gets goal from blueprint if none is given
             if self.goal == [-1, -1, -1]:
                 print(Fore.MAGENTA + "erm blueprint done in the wrong place")
@@ -186,6 +187,8 @@ class Inchworm:
         Returns the set of the next points of inchworm travel. Used for stepping through path for sim.
         """
         self.leading_foot_loc = self.paths[self.goal_progress_index]  # Get the next point
+        self.lagging_foot_loc = self.paths[self.goal_progress_index - 1]
+        
         x, y, z = self.leading_foot_loc
         self.goal_progress_index += 1
         

--- a/inchworm_control/block_simulation/map_data.py
+++ b/inchworm_control/block_simulation/map_data.py
@@ -103,9 +103,15 @@ def update_grid_status(grid, coord, status: GridStatus=GridStatus.NOT_WALKABLE):
     x, y, z = coord
 
     if is_valid_position_3d(grid, coord):
-        grid[x][y][z] = GridStatus.WALKABLE.value #curr cell
-        if z - 1 >= 0:
-            grid[x][y][z-1] = status.value #cell below
+        if status != GridStatus.INCOMING_BLOCK:
+            grid[x][y][z] = GridStatus.WALKABLE.value #curr cell
+            if z - 1 >= 0:
+                grid[x][y][z-1] = status.value #cell below
+        else:
+            grid[x][y][z] = GridStatus.INCOMING_BLOCK.value
+            if z - 1 >= 0:
+                grid[x][y][z-1] = GridStatus.NOT_WALKABLE.value #cell below
+
     return grid
 
 def set_inchworm_path_to_grid(grid, inchworm_path, iw_id):
@@ -148,22 +154,6 @@ def rm_inchworm_path_from_grid(grid, inchworm_path):
                 grid[x][y][z] = GridStatus.WALKABLE.value
     return grid
 
-def rm_inchworm_path_from_grid(grid, inchworm_path):
-    """
-    Remove the inchworm path from the grid.
-
-    Args:
-        grid (list): A 3D list representing the workspace, where each element indicates whether
-                     the corresponding cell is walkable (0), not (1), inchworm_path (-inchworm_id), 
-                     incoming_block (2), & supply_depot (3). 
-    Returns:
-        grid (list): An updated 3D list (grid) of the current map snapshot. 
-    """ 
-    inchworm_path.pop(-1)
-    for step in range(len(inchworm_path)-1): 
-        x, z, y = inchworm_path[step]
-        grid[x][z][y] = GridStatus.WALKABLE.value
-    return grid
 
 def set_neighbors(allow_vertical=True, allow_vert_diagonal=True, allow_horz_diagonal=False, allow_alls_diagonal=False, allow_large_build=False):    
     """

--- a/inchworm_control/block_simulation/sim.py
+++ b/inchworm_control/block_simulation/sim.py
@@ -190,7 +190,7 @@ def update():
             last_colored_block_2 = spawned_block_2
             last_block_original_texture_2 = smart_block_texture
 
-        sim_data.existing_inchworms[0].lagging_foot_loc = sim_data.existing_inchworms[0].leading_foot_loc
+        # sim_data.existing_inchworms[0].lagging_foot_loc = sim_data.existing_inchworms[0].leading_foot_loc
         key_n_pressed = False
 
 
@@ -232,7 +232,9 @@ def vis_IW_paths(inchworm, clear_path=False):
             seed_block_texture_step : seed_block_texture,
             smart_block_texture_step : smart_block_texture, 
             smart_block_texture_step_red : white_block_texture, 
-            smart_block_outline : incoming_step_block_texture
+            smart_block_outline : incoming_step_block_texture, 
+            incoming_block_texture : incoming_block_texture
+
         }
         block_color = transition[already_placed_block.texture]
         # print("new texture: ", block_color)

--- a/inchworm_control/inchworm_control/blueprint.py
+++ b/inchworm_control/inchworm_control/blueprint.py
@@ -49,7 +49,8 @@ def blueprint(curr_map, final_map) -> list:
                     for y in range(curr_map.shape[1]): #iterate 0-7
                         is_different = curr_map[x, y, z] != final_map[x, y, z]
                         final_is_walkable = final_map[x, y, z] == 0
-                        lowest_z = None
+                        lowest_z = z
+
                         
                         for zz in range((curr_map.shape[2])):
                             curr_is_walkable = curr_map[x, y, zz] == 0


### PR DESCRIPTION
* sim works

* simple state machine done and complete yipper

* cleaned up the code

* cleaned up the code

* removed temp, calling map_data

* IW SM -> inchworm_data

* rm show_structs return

* deleted state_machine.py

* TESTING WAHHHHHHHHHHHHHHHH

* reverted my changes so path conversion works for everyone

* combining stuff

* sim checks blocks for inchworm

* unused seed block

* blueprint works

* working on step logic, fixed bfs, works now!

* esc to leave sim

* done for the night, i tire

* stupid subfirectories wont work

* more fixing import stuff

* made it work!

* testing

* sim to blueprint

* update sim textures w IW's path/incoming block

* seed block texture

* mo' testin

* blueprint based on sim-made struct

* blueprint algo works w sim

* fixed path plan

* fsjkkhakef

* vndjfksfvnakjl

* bfs not searching vert

* found issue with bfs, made changes in how grid changes are changed and passing in holding block

* path plans to supply depot

* find_path handles BD & holding_block

* path to steps works :D

* incoming block/path visible

* steps through path

* Test UART connection

* Test UART connection lol

* fixed state machine transitions

* Mo's CRC16 function checksum

* initilization block com

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* init block message works

* IW moves through BD correctly

* replaces incoming block in sim

* entry to state machine in sim

* buh bye tracys testing corner

* checkers & move through init phase

* added some comments

* added question logic back

* added question logic back

* added some comments

* added a flag for seed block logic

* added a flag for seed block logic

* generate final struct visible, clears map

* spawn seedB as first block of final struct

* polished state machine

* IW at supply com

* IW at supply com

* debug

* debug

* debug

* debug

* debug

* debug

* debug

* send_block_being_placed

* debug

* debug

* debug

* added a IW_path dummy value

* cleaned spawn_cube

* Block inchworm com (#15)

* Test UART connection lol

* fixed state machine transitions

* Mo's CRC16 function checksum

* initilization block com

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* debugging

* init block message works

* Inchworm order of operation: Path planning to first block (#14)

* sim works

* simple state machine done and complete yipper

* cleaned up the code

* cleaned up the code

* removed temp, calling map_data

* IW SM -> inchworm_data

* rm show_structs return

* deleted state_machine.py

* TESTING WAHHHHHHHHHHHHHHHH

* reverted my changes so path conversion works for everyone

* combining stuff

* sim checks blocks for inchworm

* unused seed block

* blueprint works

* working on step logic, fixed bfs, works now!

* esc to leave sim

* done for the night, i tire

* stupid subfirectories wont work

* more fixing import stuff

* made it work!

* testing

* sim to blueprint

* update sim textures w IW's path/incoming block

* seed block texture

* mo' testin

* blueprint based on sim-made struct

* blueprint algo works w sim

* fixed path plan

* fsjkkhakef

* vndjfksfvnakjl

* bfs not searching vert

* found issue with bfs, made changes in how grid changes are changed and passing in holding block

* path plans to supply depot

* find_path handles BD & holding_block

* path to steps works :D

* incoming block/path visible

* steps through path

* IW moves through BD correctly

* replaces incoming block in sim

---------




* Test UART connection

* added some comments

* added question logic back

* added question logic back

* added some comments

* added a flag for seed block logic

* added a flag for seed block logic

* polished state machine

* IW at supply com

* IW at supply com

* debug

* debug

* debug

* debug

* debug

* debug

* debug

* send_block_being_placed

* debug

* debug

* debug

* added a IW_path dummy value

---------




* merging block coms into iw state machine

* only tries esablishing uart if not sim

* Clean up (#17)

* dusting

* troubles with parallelizing plan path to fix multiple uses

* continuing to work on plan_path, also made update_grid_with_coord to be more flexible

* changed code to reflect changes to update_grid_status

* got rid of holding_block in path_coords, debatable if we keep it or not. makes code cleaner

* thinks it has block when doesnt, debuggin to be continued

* successfully steps through correctly while also not having to pass holding_block at every step

* seed block in IW

* idk why blueprint index fixed

* idk why blueprint index fixed

* new path plan worksgit status

* IGNORE testing ssh github

* struct comms v1

* new order to comms & SM

* seed_bk & supply dpt spawn from start

* testing the blueprint algo

* blueprint & final struct update maybe fixed

* sim can path plan to next block

* no handle if IW is not at block/supply

* cleanup

* maps init with seed block

* No crashing (#19)

* NEED TO TEST: implemented buffer for other iw paths

* map_data x z y -> x y z

* bfs x z y -> x y z

* changed x z y -> x y z

* more x z y to x y z

* correct blueprint (in x y z now)

* remove some prints

* works rn AHH

* added 3 block stack, have not tested yet. working on correcting pp to reflect what we want it to do physically.

* xzy -> xyz except spawn cube

* fixed adding to final struct & blueprint for xyz

* xyz in sim, except for voxels

* layer by layer blueprint

* Revert "layer by layer blueprint"

This reverts commit 18637b80893b4b8d646b396bf9a928ec10a3ce41.

* path removal restores supply depot in map

* handles error if can't comm at supply depot

* texture modification instead of respawning

* quick changes

* stacking works! (in blue print) also changed the text colors to colorcode print statements. need to fix pathplanning to better rep irl

* fixed colors

* mini change

* demo works in simulation

* no longer walkable on incoming blocks

* lagging foot updates in IW state machine

---------